### PR TITLE
Fixed blocking call during NefitCore creation reported in https://github.com/ksya/ha-nefiteasy/ #346

### DIFF
--- a/aionefit/provider/slixmpp_impl.py
+++ b/aionefit/provider/slixmpp_impl.py
@@ -1,10 +1,18 @@
 import slixmpp
 import asyncio
 import logging
+import ssl
 from slixmpp.xmlstream import tostring
 
 _LOGGER = logging.getLogger(__name__)
 
+# Custom SSL Context to avoid blocking calls. Needs slixmpp >= 1.9.1
+# Created with the same parameters as in slixmpp XMLStream class
+SSL_CONTEXT = ssl.create_default_context()
+SSL_CONTEXT.set_ciphers("DEFAULT")
+SSL_CONTEXT.check_hostname = True
+SSL_CONTEXT.verify_mode = ssl.CERT_REQUIRED
+SSL_CONTEXT.set_default_verify_paths()
 
 class NefitXmppClient(slixmpp.ClientXMPP):
     """XMPP client implementation using the slixmpp library
@@ -13,7 +21,8 @@ class NefitXmppClient(slixmpp.ClientXMPP):
     def __init__(self, jid, password, encryption, nefit_client=None):
 
         slixmpp.ClientXMPP.__init__(self, jid, password,
-                                    sasl_mech="DIGEST-MD5")
+                                    sasl_mech="DIGEST-MD5",
+                                    ssl_context=SSL_CONTEXT)
         self.nefit_client = nefit_client
         # the event signaling, that the connection is established
         self.connected_event = asyncio.Event()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyaes
-slixmpp==1.8.2
+slixmpp


### PR DESCRIPTION
1. Passing custom SSL context to slixmpp lib in the same way as it was done in other HACS custom integrations. Requires slixmpp >= 1.91.
2. Changed requirements.txt to always use latest slixmpp
