### PR TITLE
Release 0.16 preparation: Updated minimal supported Python version, package version, and slixmpp version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,6 @@ setup(
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,13 @@ DESCRIPTION = 'asyncio library for Bosch thermostats'
 URL = 'https://github.com/spoetnik/aionefit'
 EMAIL = 'm.degeus@nise.nl'
 AUTHOR = 'Martijn de Geus'
-REQUIRES_PYTHON = '>=3.5.0'
-VERSION = "0.15"
+REQUIRES_PYTHON = '>=3.9.0'
+VERSION = "0.16"
 
 # What packages are required for this module to be executed?
 REQUIRED = [
     "pyaes",
-    "slixmpp==1.8.2"
+    "slixmpp==1.11.0"
 ]
 
 # What packages are optional?


### PR DESCRIPTION
Minimal supported Python version is set to 3.9, the same as slixmpp 1.11.0 supports
Removed license classifiers to avoid warnings with latest setuptools
Tested with latest pip, wheel, and setuptools